### PR TITLE
[bug fix]  pass parameters explicitly in transform_img to avoid prarameter missing error

### DIFF
--- a/tools/demo.py
+++ b/tools/demo.py
@@ -159,9 +159,13 @@ class Infer():
 
     def preprocess(self, origin_img):
 
-        img = transform_img(origin_img, 0,
-                **self.config.test.augment.transform,
-                infer_size=self.infer_size)
+        img = transform_img(origin_img=origin_img,
+                            size_divisibility=0,
+                            image_max_range=self.config.test.augment.transform['image_max_range'],
+                            flip_prob=self.config.test.augment.transform['flip_prob'],
+                            image_mean=self.config.test.augment.transform['image_mean'],
+                            image_std=self.config.test.augment.transform['image_std'])
+                            infer_size=self.infer_size)
         img = self._pad_image(img.tensors, self.infer_size)
         # img is a image_list
         ratio = min(origin_img.shape[0] / img.image_sizes[0][0],

--- a/tools/demo.py
+++ b/tools/demo.py
@@ -164,7 +164,7 @@ class Infer():
                             image_max_range=self.config.test.augment.transform['image_max_range'],
                             flip_prob=self.config.test.augment.transform['flip_prob'],
                             image_mean=self.config.test.augment.transform['image_mean'],
-                            image_std=self.config.test.augment.transform['image_std'])
+                            image_std=self.config.test.augment.transform['image_std'],
                             infer_size=self.infer_size)
         img = self._pad_image(img.tensors, self.infer_size)
         # img is a image_list


### PR DESCRIPTION
Thank you for your great work.

I made a little fix for a bug that seems to be caused by the addition of keep_ratio. What do you think?

The error is below.
```
2023-03-01 09:33:22.532 | ERROR    | __main__:<module>:360 - An error has been caught in function '<module>', process 'MainProcess' (5257), thread 'MainThread' (140704481396928):
Traceback (most recent call last):

> File "tools/demo.py", line 360, in <module>
    main()
    └ <function main at 0x7f84c06e5160>

  File "tools/demo.py", line 344, in main
    bboxes, scores, cls_inds = infer_engine.forward(frame)
                               │            │       └ array([[[ 12,  19,  20],
                               │            │                 [ 13,  18,  20],
                               │            │                 [ 14,  18,  20],
                               │            │                 ...,
                               │            │                 [128, 112,  96],
                               │            │                 [125...
                               │            └ <function Infer.forward at 0x7f84c06e2f70>
                               └ <__main__.Infer object at 0x7f84c06c59d0>

  File "tools/demo.py", line 233, in forward
    image, ratio = self.preprocess(image)
    │              │    │          └ array([[[ 12,  19,  20],
    │              │    │                    [ 13,  18,  20],
    │              │    │                    [ 14,  18,  20],
    │              │    │                    ...,
    │              │    │                    [128, 112,  96],
    │              │    │                    [125...
    │              │    └ <function Infer.preprocess at 0x7f84c06e2e50>
    │              └ <__main__.Infer object at 0x7f84c06c59d0>
    └ array([[[ 12,  19,  20],
              [ 13,  18,  20],
              [ 14,  18,  20],
              ...,
              [128, 112,  96],
              [125...

  File "tools/demo.py", line 166, in preprocess
    img = transform_img(origin_img, 0,
          │             └ array([[[ 12,  19,  20],
          │                       [ 13,  18,  20],
          │                       [ 14,  18,  20],
          │                       ...,
          │                       [128, 112,  96],
          │                       [125...
          └ <function transform_img at 0x7f84e02ab9d0>

TypeError: transform_img() got an unexpected keyword argument 'keep_ratio'
```

best regards, :-D