### PR TITLE
[Bug fix] Add keep_ratio argument in damo/utils/demo_utils transform_img

### DIFF
--- a/damo/utils/demo_utils.py
+++ b/damo/utils/demo_utils.py
@@ -100,9 +100,9 @@ def demo_postprocess(outputs, img_size, p6=False):
 
 
 def transform_img(origin_img, size_divisibility, image_max_range, flip_prob,
-                  image_mean, image_std, infer_size=None):
+                  image_mean, image_std, keep_ratio, infer_size=None):
     transform = [
-        T.Resize(image_max_range, target_size=infer_size),
+        T.Resize(image_max_range, target_size=infer_size, keep_ratio=keep_ratio),
         T.RandomHorizontalFlip(flip_prob),
         T.ToTensor(),
         T.Normalize(mean=image_mean, std=image_std),


### PR DESCRIPTION
Thank you for your work.

I have some error when running demo and make minor change on demo_utils. I add keep_ratio argument to transform_img and T.Resize by referring to your previous code.

## referred code
https://github.com/tinyvision/DAMO-YOLO/blob/master/damo/dataset/transforms/build.py#L8

## Things to keep in mind when writing code
Actually there is pull request and sorry to @mucunwuxian.
https://github.com/tinyvision/DAMO-YOLO/pull/83

**However**, transform_img use test_transform(config object)  in damo/config/augmentation. So consistency between test_transform and transform_img is important. Also is easy way to change demo augmentation using Config object.  

It is simillar to code in [referred code](https://github.com/tinyvision/DAMO-YOLO/blob/master/damo/dataset/transforms/build.py#L8).

## Error Stack
```bash
~/Desktop/DAMO-YOLO$ python tools/demo.py -f ./configs/damoyolo_tinynasL25_S.py --engine ./damoyolo_tinynasL25_S.pth --engine_type torch --conf 0.6 --infer_size 640 640 --device cuda --path ./assets/dog.jpg
Inference with torch engine!
2023-03-07 14:34:29.694 | ERROR    | __main__:<module>:349 - An error has been caught in function '<module>', process 'MainProcess' (12971), thread 'MainThread' (140577041479488):
Traceback (most recent call last):

> File "/mnt/c/Users/WonbeomJang/Desktop/DAMO-YOLO/tools/demo.py", line 349, in <module>
    main()
    └ <function main at 0x7fd9e1bcc9d0>

  File "/mnt/c/Users/WonbeomJang/Desktop/DAMO-YOLO/tools/demo.py", line 313, in main
    bboxes, scores, cls_inds = infer_engine.forward(origin_img)
                               │            │       └ array([[[ 57,  58,  50],
                               │            │                 [ 58,  59,  51],
                               │            │                 [ 60,  61,  53],
                               │            │                 ...,
                               │            │                 [142,  89,  47],
                               │            │                 [ 88...
                               │            └ <function Infer.forward at 0x7fd9e1bcc820>
                               └ <__main__.Infer object at 0x7fd9e1bdd580>

  File "/mnt/c/Users/WonbeomJang/Desktop/DAMO-YOLO/tools/demo.py", line 223, in forward
    image, ratio = self.preprocess(image)
    │              │    │          └ array([[[ 57,  58,  50],
    │              │    │                    [ 58,  59,  51],
    │              │    │                    [ 60,  61,  53],
    │              │    │                    ...,
    │              │    │                    [142,  89,  47],
    │              │    │                    [ 88...
    │              │    └ <function Infer.preprocess at 0x7fd9e1bcc700>
    │              └ <__main__.Infer object at 0x7fd9e1bdd580>
    └ array([[[ 57,  58,  50],
              [ 58,  59,  51],
              [ 60,  61,  53],
              ...,
              [142,  89,  47],
              [ 88...

  File "/mnt/c/Users/WonbeomJang/Desktop/DAMO-YOLO/tools/demo.py", line 162, in preprocess
    img = transform_img(origin_img, 0,
          │             └ array([[[ 57,  58,  50],
          │                       [ 58,  59,  51],
          │                       [ 60,  61,  53],
          │                       ...,
          │                       [142,  89,  47],
          │                       [ 88...
          └ <function transform_img at 0x7fd9e1bcc430>

TypeError: transform_img() got an unexpected keyword argument 'keep_ratio'
```

## Result
```bash
~/Desktop/DAMO-YOLO$ python tools/demo.py -f ./configs/damoyolo_tinynasL25_S.py --engine ./damoyolo_tinynasL25_S.onnx --engine_type onnx --conf 0.6 --infer_size 640 640 --device cuda --path ./assets/dog.jpg
Inference with onnx engine!
save visualization results at ./demo/dog.jpg
```
![dog](https://user-images.githubusercontent.com/40621030/223333772-d6c5514e-a524-4bf9-b371-17bfe1d6868b.jpg)
